### PR TITLE
Update unit test to check for null

### DIFF
--- a/test/Jaahas.CertificateUtilities.Tests/CertificateLocationTests.cs
+++ b/test/Jaahas.CertificateUtilities.Tests/CertificateLocationTests.cs
@@ -54,7 +54,8 @@ namespace Jaahas.CertificateUtilities.Tests {
         public void ShouldNotLoadCertificateFromStore(string path) {
             var location = CertificateLocation.CreateFromPath(path);
             var loader = new CertificateLoader();
-            Assert.ThrowsException<InvalidOperationException>(() => loader.LoadCertificate(location));
+            var cert = loader.LoadCertificate(location);
+            Assert.IsNull(cert);
         }
 
 


### PR DESCRIPTION
#8 requires a change to the ShouldNotLoadCertificateFromStore test to ensure that the loader returns null rather than throwing an exception.